### PR TITLE
fix: hardcoded FlowTenant in auth headers and incompatible dependency versions on Python 3.12+

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,122 @@ The application orchestrates a flow through 6 predefined prompt steps:
    
    Then edit the `.env` file to add your API keys for the providers you want to use (OpenAI and/or Anthropic).
 
+## LLM Providers
+
+The BCP Calculator supports four LLM providers, selected via the `--provider` flag. Each requires its own set of environment variables in your `.env` file.
+
+---
+
+### OpenAI (`--provider openai`)
+
+Connects directly to the OpenAI API using `langchain-openai`.
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `OPENAI_API_KEY` | Yes | — | Your OpenAI API key |
+| `OPENAI_MODEL_NAME` | No | `gpt-4o-2024-05-13` | Model to use |
+
+**.env example:**
+```env
+OPENAI_API_KEY=sk-...
+OPENAI_MODEL_NAME=gpt-4o-2024-05-13
+```
+
+**Usage:**
+```bash
+python run_cli.py story.md --provider openai
+```
+
+---
+
+### Anthropic Claude (`--provider claude`)
+
+Connects directly to the Anthropic API using `langchain-anthropic`.
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `ANTHROPIC_API_KEY` | Yes | — | Your Anthropic API key |
+| `ANTHROPIC_MODEL_NAME` | No | `claude-3-sonnet-20240229-v1:0` | Model to use |
+
+**.env example:**
+```env
+ANTHROPIC_API_KEY=sk-ant-...
+ANTHROPIC_MODEL_NAME=claude-3-sonnet-20240229-v1:0
+```
+
+**Usage:**
+```bash
+python run_cli.py story.md --provider claude
+```
+
+---
+
+### Flow OpenAI (`--provider flow-openai`)
+
+Routes requests through [CI&T Flow](https://flow.ciandt.com)'s OpenAI-compatible orchestration layer. Authenticates via client credentials (exchanged for a Bearer token automatically).
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `FLOW_BASE_URL` | Yes | — | Flow base URL (e.g. `https://flow.ciandt.com`) |
+| `FLOW_CLIENT_ID` | Yes | — | Flow API client ID |
+| `FLOW_CLIENT_SECRET` | Yes | — | Flow API client secret |
+| `FLOW_TENANT` | No | `flowteam` | Tenant identifier sent in the `FlowTenant` header |
+| `FLOW_AGENT` | No | `bcp-opensource` | Agent identifier sent in the `FlowAgent` header |
+| `FLOW_MODEL_NAME` | No | `gpt-4o-mini` | Model to use (OpenAI-compatible names) |
+| `FLOW_MAX_TOKENS` | No | `4096` | Maximum tokens to generate |
+
+**.env example:**
+```env
+FLOW_BASE_URL=https://flow.ciandt.com
+FLOW_CLIENT_ID=my-client-id
+FLOW_CLIENT_SECRET=my-client-secret
+FLOW_TENANT=myteam
+FLOW_AGENT=bcp-opensource
+FLOW_MODEL_NAME=gpt-4o-mini
+```
+
+**Usage:**
+```bash
+python run_cli.py story.md --provider flow-openai
+```
+
+---
+
+### Flow Bedrock (`--provider flow-bedrock`)
+
+Routes requests through CI&T Flow's Bedrock endpoint, which provides access to AWS Bedrock models (including Claude via Bedrock). Uses the same client credentials authentication as `flow-openai`.
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `FLOW_BASE_URL` | Yes | — | Flow base URL (e.g. `https://flow.ciandt.com`) |
+| `FLOW_CLIENT_ID` | Yes | — | Flow API client ID |
+| `FLOW_CLIENT_SECRET` | Yes | — | Flow API client secret |
+| `FLOW_TENANT` | No | `flowteam` | Tenant identifier sent in the `FlowTenant` header |
+| `FLOW_AGENT` | No | `bcp-opensource` | Agent identifier sent in the `FlowAgent` header |
+| `FLOW_BEDROCK_MODEL_NAME` | No | `anthropic.claude-3-5-haiku` | Bedrock model ID |
+| `FLOW_BEDROCK_MAX_TOKENS` | No | `1000` | Maximum tokens to generate |
+| `FLOW_BEDROCK_TEMPERATURE` | No | `1.0` | Sampling temperature |
+| `FLOW_BEDROCK_TOP_P` | No | `0.999` | Top-p sampling |
+| `FLOW_BEDROCK_TOP_K` | No | `250` | Top-k sampling |
+| `FLOW_BEDROCK_ANTHROPIC_VERSION` | No | `bedrock-2023-05-31` | Anthropic API version for Bedrock |
+
+**.env example:**
+```env
+FLOW_BASE_URL=https://flow.ciandt.com
+FLOW_CLIENT_ID=my-client-id
+FLOW_CLIENT_SECRET=my-client-secret
+FLOW_TENANT=myteam
+FLOW_BEDROCK_MODEL_NAME=anthropic.claude-3-5-haiku
+FLOW_BEDROCK_MAX_TOKENS=1000
+```
+
+**Usage:**
+```bash
+python run_cli.py story.md --provider flow-bedrock
+```
+
+---
+
 ## Integration Options
 
 The BCP Calculator can be used in five different ways:

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,9 +16,9 @@ pydantic==2.11.7
 requests==2.32.3
 
 # Analysis and visualization dependencies
-pandas==2.0.0
-matplotlib==3.5.0
-openpyxl==3.0.9
+pandas==2.2.3
+matplotlib==3.9.4
+openpyxl==3.1.5
 
 # MCP server support
 mcp[cli]

--- a/src/bcp/llm_providers.py
+++ b/src/bcp/llm_providers.py
@@ -267,7 +267,7 @@ class FlowProvider(LLMProvider):
         headers = {
             "accept": "/",
             "Content-Type": "application/json",
-            "FlowTenant": "flowteam",
+            "FlowTenant": os.environ.get("FLOW_TENANT", "flowteam"),
         }
 
         payload = {
@@ -490,7 +490,7 @@ class FlowBedrockProvider(LLMProvider):
         headers = {
             "accept": "/",
             "Content-Type": "application/json",
-            "FlowTenant": "flowteam",
+            "FlowTenant": os.environ.get("FLOW_TENANT", "flowteam"),
         }
 
         payload = {


### PR DESCRIPTION
Two bugs prevented the project from running on Python 3.12+ environments with non-default Flow tenants:

1. `FlowTenant` header hardcoded in the OAuth token request, causing `401 Unauthorized` for any tenant other than `flowteam`
2. `pandas==2.0.0` failing to build from source on Python 3.12+ due to a removed `pkg_resources` dependency

---

## Fix 1 — `src/bcp/llm_providers.py`: FlowTenant hardcoded in authentication headers

### Root cause

`FlowProvider._get_flow_token()` and `FlowBedrockProvider._get_flow_token()` both build the HTTP headers for the OAuth token request against `https://flow.ciandt.com/auth-engine-api/v1/api-key/token`. The `FlowTenant` header in that request was hardcoded as `"flowteam"` instead of reading from `FLOW_TENANT` env var.

The inconsistency is subtle: `self.flow_tenant` is correctly populated from `os.environ.get("FLOW_TENANT")` on `__init__` (line 255 / line 474), and the same env var is correctly used when building chat request headers. Only the auth token request was using the hardcoded value.

### Error

```
2026-05-27 13:11:07 - bcp_calculator - ERROR - Error calculating BCP: \
  Error calling Flow API: 401 Client Error: Unauthorized for url: \
  https://flow.ciandt.com/auth-engine-api/v1/api-key/token
```

### Fix

Applied to both `FlowProvider._get_flow_token()` (line 270) and `FlowBedrockProvider._get_flow_token()` (line 493):

```python
# before — in both FlowProvider and FlowBedrockProvider
headers = {
    "accept": "/",
    "Content-Type": "application/json",
    "FlowTenant": "flowteam",   # hardcoded, ignores FLOW_TENANT env var
}

# after
headers = {
    "accept": "/",
    "Content-Type": "application/json",
    "FlowTenant": os.environ.get("FLOW_TENANT", "flowteam"),  # reads from env, falls back to "flowteam"
}
```

---

## Fix 2 — `requirements.txt`: dependency versions incompatible with Python 3.12+

### Root cause

`pandas==2.0.0` ships only as a source distribution (`.tar.gz`) for Python 3.12+ — no pre-built wheel is available for this version. Its `setup.py` imports `pkg_resources` at build time, which was removed from the default `setuptools` installation in newer versions. This caused the entire `pip install` to abort before any package was installed.

`matplotlib==3.5.0` and `openpyxl==3.0.9` were also pinned to versions predating Python 3.12 and would have caused similar build failures or numpy compatibility errors downstream.

### Error

```
Getting requirements to build wheel: finished with status 'error'

× Getting requirements to build wheel did not run successfully.
│ exit code: 1
╰─> [20 lines of output]
    ...
    File "<string>", line 19, in <module>
  ModuleNotFoundError: No module named 'pkg_resources'

ERROR: Failed to build 'pandas' when getting requirements to build wheel
```

### Fix

Bumped to the latest stable patch releases that ship pre-built wheels for Python 3.12 on macOS (arm64) and Linux (x86_64), eliminating the source build entirely:

| Package | Before | After | Reason |
|---|---|---|---|
| `pandas` | `2.0.0` | `2.2.3` | First version with Python 3.12 wheels; no `pkg_resources` dependency |
| `matplotlib` | `3.5.0` | `3.9.4` | Compatible with numpy ≥2.0 pulled by pandas 2.2.x |
| `openpyxl` | `3.0.9` | `3.1.5` | Fixes `et_xmlfile` compatibility on newer Python versions |

No breaking API changes between old and new versions for the usage in this project (`pandas.DataFrame`, `matplotlib.pyplot`, `openpyxl` via pandas `.to_excel()`).
